### PR TITLE
Parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ exclude = [
     "tests/data",
 ]
 
-
+[features]
+parallel = ['rayon']
 
 [dependencies]
 num-traits = "0.2.8"
 byteorder = "1.3.1"
 
-
+rayon = { version = "1.2.0", optional = true }

--- a/examples/check_compression.rs
+++ b/examples/check_compression.rs
@@ -3,7 +3,6 @@ use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 
 use laz::las::file::QuickHeader;
 use laz::las::laszip::{LasZipCompressor, LasZipDecompressor, LazItemRecordBuilder};
-use laz::las::{Point0, Point1, Point2, Point3, Point6, Point7, Point8};
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -15,7 +14,7 @@ fn main() {
         .seek(SeekFrom::Start(las_header.offset_to_points as u64))
         .unwrap();
 
-    let laz_items = let laz_items = LazItemRecordBuilder::default_for_point_format_id(las_header.point_format_id, 0);
+    let laz_items =  LazItemRecordBuilder::default_for_point_format_id(las_header.point_format_id, 0);
     let mut compressor =
         LasZipCompressor::from_laz_items(Cursor::new(Vec::<u8>::new()), laz_items).unwrap();
 

--- a/examples/check_compression.rs
+++ b/examples/check_compression.rs
@@ -15,19 +15,7 @@ fn main() {
         .seek(SeekFrom::Start(las_header.offset_to_points as u64))
         .unwrap();
 
-    let laz_items = match las_header.point_format_id {
-        0 => LazItemRecordBuilder::default_version_of::<Point0>(0),
-        1 => LazItemRecordBuilder::default_version_of::<Point1>(0),
-        2 => LazItemRecordBuilder::default_version_of::<Point2>(0),
-        3 => LazItemRecordBuilder::default_version_of::<Point3>(0),
-        6 => LazItemRecordBuilder::default_version_of::<Point6>(0),
-        7 => LazItemRecordBuilder::default_version_of::<Point7>(0),
-        8 => LazItemRecordBuilder::default_version_of::<Point8>(0),
-        _ => panic!(
-            "Point format id: {} is not supported",
-            las_header.point_format_id
-        ),
-    };
+    let laz_items = let laz_items = LazItemRecordBuilder::default_for_point_format_id(las_header.point_format_id, 0);
     let mut compressor =
         LasZipCompressor::from_laz_items(Cursor::new(Vec::<u8>::new()), laz_items).unwrap();
 

--- a/examples/par_compression.rs
+++ b/examples/par_compression.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "parallel")]
+fn main() {
+    use laz::las::laszip::{par_compress_all, LazItemRecordBuilder};
+    use laz::las::file::QuickHeader;
+    use std::io::{BufReader, Seek, SeekFrom, Cursor};
+    use std::fs::File;
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut las_file = BufReader::new(File::open(&args[1]).unwrap());
+    let las_header = QuickHeader::read_from(&mut las_file).unwrap();
+
+    las_file.seek(SeekFrom::Start(las_header.offset_to_points as u64)).unwrap();
+
+    let all_points = vec![0u8; las_header.point_size as usize * las_header.num_points as usize];
+    let laz_items = LazItemRecordBuilder::default_for_point_format_id(las_header.point_format_id, 0);
+
+
+    let mut compression_out_put = Cursor::new(Vec::<u8>::new());
+    par_compress_all(&mut compression_out_put, &all_points, laz_items).unwrap();
+}
+
+#[cfg(not(feature = "parallel"))]
+fn main() {
+    println!("laz-rs wasn't compiled with parallel feature");
+}

--- a/examples/par_decompression.rs
+++ b/examples/par_decompression.rs
@@ -1,0 +1,41 @@
+use laz::las::file::{read_vlrs_and_get_laszip_vlr, SimpleReader, point_format_id_compressed_to_uncompressd};
+
+#[cfg(feature = "parallel")]
+fn main() {
+    use laz::las::laszip::{par_decompress_all};
+    use laz::las::file::QuickHeader;
+    use std::io::{BufReader, Seek, SeekFrom};
+    use std::fs::File;
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut laz_file = BufReader::new(File::open(&args[1]).unwrap());
+    let laz_header = QuickHeader::read_from(&mut laz_file).unwrap();
+    laz_file.seek(SeekFrom::Start(laz_header.header_size as u64)).unwrap();
+    let laszip_vlr = read_vlrs_and_get_laszip_vlr(&mut laz_file, &laz_header).expect("no laszip vlr found");
+
+
+    laz_file.seek(SeekFrom::Start(laz_header.offset_to_points as u64)).unwrap();
+
+    let mut all_points = vec![0u8; laz_header.point_size as usize * laz_header.num_points as usize];
+
+    par_decompress_all(&mut laz_file, &mut all_points, &laszip_vlr).unwrap();
+
+    if let Some(las_path) = args.get(2) {
+        let mut las_file = SimpleReader::new(BufReader::new(File::open(las_path).unwrap())).unwrap();
+        assert_eq!(las_file.header.point_format_id, point_format_id_compressed_to_uncompressd(laz_header.point_format_id));
+        assert_eq!(las_file.header.num_points, laz_header.num_points);
+        for i in 0..laz_header.num_points as usize {
+            let las_point = las_file.read_next().unwrap().unwrap();
+            let decompress_point = &all_points[(i * laz_header.point_size as usize)..(i+1)* laz_header.point_size as usize];
+            assert_eq!(decompress_point, las_point);
+        }
+
+    } else {
+        println!("No LAS file path given, decompression result can't be checked");
+    }
+}
+
+#[cfg(not(feature = "parallel"))]
+fn main() {
+    println!("laz-rs wasn't compiled with parallel feature");
+}

--- a/examples/par_decompression.rs
+++ b/examples/par_decompression.rs
@@ -1,7 +1,7 @@
-use laz::las::file::{read_vlrs_and_get_laszip_vlr, SimpleReader, point_format_id_compressed_to_uncompressd};
 
 #[cfg(feature = "parallel")]
 fn main() {
+    use laz::las::file::{read_vlrs_and_get_laszip_vlr, SimpleReader, point_format_id_compressed_to_uncompressd};
     use laz::las::laszip::{par_decompress_all};
     use laz::las::file::QuickHeader;
     use std::io::{BufReader, Seek, SeekFrom};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@ pub enum LasZipError {
     UnknownCompressorType(u16),
     UnsupportedCompressorType(CompressorType),
     IoError(std::io::Error),
+    BufferLenNotMultipleOfPointSize{buffer_len: usize, point_size: usize}
 }
 
 impl From<std::io::Error> for LasZipError {
@@ -32,6 +33,10 @@ impl fmt::Display for LasZipError {
                 write!(f, "Compressor type {:?} is not supported", compressor_type)
             }
             LasZipError::IoError(e) => write!(f, "IoError: {}", e),
+
+            LasZipError::BufferLenNotMultipleOfPointSize { buffer_len: bl, point_size: ps } => {
+                write!(f, "The len of the buffer ({}) is not a multiple of the point size {}", bl, ps)
+            }
         }
     }
 }


### PR DESCRIPTION
Introduce par_compress_all & par_decompress_all 
to compress / decompress in multiple threads.

It uses rayon's parallel iterators.

To have this functions the crate must be compiled with the 'parallel' feature enabled

Closes #1 