### PR TITLE
Add LICENSE.txt with inherited static linking exception

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,35 @@
+--------------------------------------------------------------------------
+
+  LICENSE AGREEMENT (for LASzip LiDAR compression):
+
+  LASzip is open-source and is licensed with the standard LGPL version 2.1
+  (see COPYING.txt) modified by the following static linking exception.
+
+  As a special exception, the copyright holders of this library give you
+  permission to link this library with independent modules to produce an
+  executable, regardless of the license terms of these independent modules,
+  and to copy and distribute the resulting executable under terms of your
+  choice, provided that you also meet, for each linked independent module,
+  the terms and conditions of the license of that module. An independent
+  module is a module which is not derived from or based on this library.
+  If you modify this library, you may extend this exception to your version
+  of the library, but you are not obliged to do so. If you do not wish to
+  do so, delete this exception statement from your version.
+
+  This software is distributed WITHOUT ANY WARRANTY and without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+--------------------------------------------------------------------------
+
+  PROGRAMMERS:
+
+  martin@rapidlasso.com (For the original c++ LASzip)
+  thomas.montaigu@laposte.net (Rust port)
+
+--------------------------------------------------------------------------
+
+  COPYRIGHT:
+
+  (c) 2007-2015, martin isenburg, rapidlasso - fast tools to catch reality
+
+--------------------------------------------------------------------------


### PR DESCRIPTION
As per the LGPL laz-rs is considered a modification of the LASzip library, thus laz-rs must be licensed under the same terms as LASzip.

LGPL only really defines how we are allowed to use the library with dynamic linking (thus static linking is not allowed).

rustc (the Rust compiler) only does static linking (between pure Rust libs).
LASzip has an exception in its LICENSE.txt allowing static linking and also allowing to extent this exception to our modification of the library.

We include that exception in the LICENSE because we basically need it.

I'm not lawyer but that's what I understand :thinking:

https://github.com/LAStools/LAStools/issues/6
https://groups.google.com/forum/#!topic/lastools/Bs9YBXzXXcg
https://github.com/LAStools/LAStools/commit/76bdb0eff89912a40b10743c0ce7853ceeafb312